### PR TITLE
remove primeng steps

### DIFF
--- a/frontend/src/app/corpus-definitions/corpus-definitions.module.ts
+++ b/frontend/src/app/corpus-definitions/corpus-definitions.module.ts
@@ -4,7 +4,6 @@ import { SharedModule } from '@shared/shared.module';
 import { QuillModule } from 'ngx-quill';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { MultiSelectModule } from 'primeng/multiselect';
-import { StepsModule } from 'primeng/steps';
 import { CreateDefinitionComponent } from './create-definition/create-definition.component';
 import { DefinitionInOutComponent } from './definition-in-out/definition-in-out.component';
 import { DefinitionJsonUploadComponent } from './definition-json-upload/definition-json-upload.component';
@@ -47,7 +46,6 @@ import { SelectModule } from 'primeng/select';
         MarkdownEditorComponent,
         SharedModule,
         ReactiveFormsModule,
-        StepsModule,
         AutoCompleteModule,
         MultiSelectModule,
         SelectModule,

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
@@ -41,12 +41,13 @@
 
 <div class="py-5">
     <div class="container-lg">
-        <ul ngbNav #nav="ngbNav" class="nav-pills" [activeId]="activeStep$ | async"
+        <ul ngbNav #nav="ngbNav" class="nav-pills nav-fill flex-column flex-md-row"
+            [activeId]="activeStep$ | async"
             (activeIdChange)="onActiveIndexChange($event)">
             @for (step of steps$ | async; let index = $index; track $index) {
                 <li [ngbNavItem]="index" [disabled]="step.disabled">
                     <button ngbNavLink>
-                        {{index + 1}} <br>
+                        <b class="m-3">{{index + 1}}</b> <br>
                         {{step.label}}
                     </button>
                     <ng-template ngbNavContent>

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
@@ -41,25 +41,40 @@
 
 <div class="py-5">
     <div class="container-lg">
-        <p-steps [model]="steps$ | async" [readonly]="false" [activeIndex]="activeStep$ | async"
-            (activeIndexChange)="onActiveIndexChange($event)" />
+        <ul ngbNav #nav="ngbNav" class="nav-pills" [activeId]="activeStep$ | async"
+            (activeIdChange)="onActiveIndexChange($event)">
+            @for (step of steps$ | async; let index = $index; track $index) {
+                <li [ngbNavItem]="index" [disabled]="step.disabled">
+                    <button ngbNavLink>
+                        {{index + 1}} <br>
+                        {{step.label}}
+                    </button>
+                    <ng-template ngbNavContent>
+                        @if (corpus$ | async; as corpus) {
+                            @switch (index) {
+                                @case (0) {
+                                    <ia-meta-form [corpus]="corpus" />
+                                }
+                                @case (1) {
+                                    <ia-data-form />
+                                }
+                                @case (2) {
+                                    <ia-field-form [corpus]="corpus" />
+                                }
+                                @case (3) {
+                                    <ia-index-form [corpus]="corpus" />
+                                }
+                            }
+                        }
+                    </ng-template>
+                </li>
+            }
+        </ul>
     </div>
 </div>
-<ng-container [ngSwitch]="activeStep$ | async">
-    <div class="py-5">
-        <div class="container-lg" *ngIf="corpus$ | async as corpus">
-            <ng-container *ngSwitchCase="0"><ia-meta-form
-                    [corpus]="corpus" /></ng-container>
-            <ia-data-form *ngSwitchCase="1" />
-            <ng-container *ngSwitchCase="2">
-                <ia-field-form [corpus]="corpus" />
-            </ng-container>
-            <p *ngSwitchCase="3">
-                <ia-index-form [corpus]="corpus" />
-            </p>
-        </div>
-    </div>
-</ng-container>
+<div class="py-5">
+    <div class="container-lg" [ngbNavOutlet]="nav"></div>
+</div>
 
 <div class="py-5" *ngIf="nextStep$ | async as nextStep">
     <div class="container-lg">

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.spec.ts
@@ -7,7 +7,6 @@ import { SlugifyPipe } from '@shared/pipes/slugify.pipe';
 import { SharedModule } from '@shared/shared.module';
 import { ApiServiceMock } from 'mock-data/api';
 import { AutoCompleteModule } from 'primeng/autocomplete';
-import { StepsModule } from 'primeng/steps';
 import { DataFormComponent } from '../data-form/data-form.component';
 import { DocumentationFormComponent } from '../documentation-form/documentation-form.component';
 import { MarkdownEditorComponent } from '../documentation-form/markdown-editor/markdown-editor.component';
@@ -37,7 +36,6 @@ describe('CorpusFormComponent', () => {
             ],
             imports: [
                 SharedModule,
-                StepsModule,
                 ReactiveFormsModule,
                 AutoCompleteModule,
                 MarkdownEditorComponent,

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -156,20 +156,6 @@ a, button, .form-control, .form-select {
     }
 }
 
-.p-steps-item.p-disabled {
-    --p-text-muted-color: var(--bs-secondary-color);
-
-    .p-steps-item-number, .p-steps-item-label {
-        color: var(--bs-secondary-color) !important;
-    }
-}
-
-:root {
-    --p-steps-item-number-active-background: var(--bs-primary-text-emphasis) !important;
-    --p-steps-item-number-active-border-color: var(--bs-primary-text-emphasis) !important;
-    --p-steps-item-label-active-color: var(--bs-primary-text-emphasis) !important;
-}
-
 
 // vega
 


### PR DESCRIPTION
Replaces the primeng steps component in the corpus form with ng-bootstrap's nav component.

The functionality is fully replaced now, but bootstrap does not have a similar "steps" layout, so this looks a lot more basic:

<img width="1842" height="963" alt="image" src="https://github.com/user-attachments/assets/7ebf9ed3-d247-429b-9336-566e2c77ba5f" />

We could add some custom CSS to restore the layout, but it does not seem high-priority for me.