### PR TITLE
Custom chips component for term comparison

### DIFF
--- a/frontend/src/app/shared/chips/chips.component.html
+++ b/frontend/src/app/shared/chips/chips.component.html
@@ -1,8 +1,9 @@
 <ul class="list-unstyled d-flex flex-wrap m-0">
-    @for (item of value(); track item) {
+    @for (item of value(); track item; let index = $index) {
         <li class="bg-secondary-subtle rounded my-1 me-2 ps-2 pe-1 d-flex align-items-center">
             {{item}}
-            <button class="btn btn-sm p-0" aria-label="remove '{{item}}'">
+            <button class="btn btn-sm p-0" aria-label="remove '{{item}}'"
+                (click)="removeItem(index)">
                 <fa-icon [icon]="actionIcons.remove" aria-hidden="true" />
             </button>
         </li>

--- a/frontend/src/app/shared/chips/chips.component.html
+++ b/frontend/src/app/shared/chips/chips.component.html
@@ -2,7 +2,7 @@
     @for (item of value(); track item; let index = $index) {
         <li class="bg-secondary-subtle rounded my-1 me-2 ps-2 pe-1 d-flex align-items-center">
             {{item}}
-            <button class="btn btn-sm p-0" aria-label="remove '{{item}}'"
+            <button class="btn btn-sm p-0" aria-label="remove {{itemName()}} '{{item}}'"
                 (click)="removeItem(index)">
                 <fa-icon [icon]="actionIcons.remove" aria-hidden="true" />
             </button>
@@ -10,7 +10,7 @@
     }
     <li class="flex-fill my-1">
         <input class="form-control-plaintext py-0" [(ngModel)]="input"
-            [attr.aria-label]="inputAriaLabel()"
+            aria-label="add {{itemName()}}"
             (keydown)="handleInputKeydown($event)">
     </li>
 </ul>

--- a/frontend/src/app/shared/chips/chips.component.html
+++ b/frontend/src/app/shared/chips/chips.component.html
@@ -11,6 +11,7 @@
     <li class="flex-fill my-1">
         <input class="form-control-plaintext py-0" [(ngModel)]="input"
             aria-label="add {{itemName()}}"
-            (keydown)="handleInputKeydown($event)">
+            (keydown)="handleInputKeydown($event)"
+            [disabled]="limitReached()">
     </li>
 </ul>

--- a/frontend/src/app/shared/chips/chips.component.html
+++ b/frontend/src/app/shared/chips/chips.component.html
@@ -1,0 +1,15 @@
+<ul class="list-unstyled d-flex flex-wrap m-0">
+    @for (item of value(); track item) {
+        <li class="bg-secondary-subtle rounded my-1 me-2 ps-2 pe-1 d-flex align-items-center">
+            {{item}}
+            <button class="btn btn-sm p-0" aria-label="remove '{{item}}'">
+                <fa-icon [icon]="actionIcons.remove" aria-hidden="true" />
+            </button>
+        </li>
+    }
+    <li class="flex-fill my-1">
+        <input class="form-control-plaintext py-0" [(ngModel)]="input"
+            [attr.aria-label]="inputAriaLabel()"
+            (keydown)="handleInputKeydown($event)">
+    </li>
+</ul>

--- a/frontend/src/app/shared/chips/chips.component.spec.ts
+++ b/frontend/src/app/shared/chips/chips.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChipsComponent } from './chips.component';
+
+describe('ChipsComponent', () => {
+    let component: ChipsComponent;
+    let fixture: ComponentFixture<ChipsComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [ChipsComponent]
+        })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(ChipsComponent);
+        component = fixture.componentInstance;
+        await fixture.whenStable();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/frontend/src/app/shared/chips/chips.component.spec.ts
+++ b/frontend/src/app/shared/chips/chips.component.spec.ts
@@ -14,6 +14,7 @@ describe('ChipsComponent', () => {
 
         fixture = TestBed.createComponent(ChipsComponent);
         component = fixture.componentInstance;
+        fixture.componentRef.setInput('itemName', 'thingamajig');
         await fixture.whenStable();
     });
 

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -19,7 +19,7 @@ import _ from 'lodash';
 export class ChipsComponent {
     value = model<string[]>([]);
     input = '';
-    inputAriaLabel = input.required<string>();
+    itemName = input.required<string>();
 
     inputConfirmKeys = ['Enter', ',', ';'];
     actionIcons = actionIcons;

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -1,0 +1,44 @@
+import { CommonModule } from '@angular/common';
+import { Component, input, model } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { actionIcons } from '../icons';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import _ from 'lodash';
+
+@Component({
+    selector: 'ia-chips',
+    imports: [CommonModule, FormsModule, FontAwesomeModule],
+    templateUrl: './chips.component.html',
+    styleUrl: './chips.component.scss',
+    host: {
+        class: 'form-control px-2 py-1',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '(focusout)': 'onBlur()',
+    },
+})
+export class ChipsComponent {
+    value = model<string[]>([]);
+    input = '';
+    inputAriaLabel = input.required<string>();
+
+    inputConfirmKeys = ['Enter', ',', ';'];
+    actionIcons = actionIcons;
+
+    handleInputKeydown(event: KeyboardEvent) {
+        if (this.inputConfirmKeys.includes(event.key)) {
+            event.preventDefault();
+            this.confirmInput();
+        }
+    }
+
+    onBlur() {
+        if (this.input.length) {
+            this.confirmInput();
+        }
+    }
+
+    confirmInput() {
+        this.value.update(value => _.uniq([...value, this.input]));
+        this.input = '';
+    }
+}

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -36,7 +36,8 @@ export class ChipsComponent {
     }
 
     confirmInput() {
-        if (this.input.length) {
+        const input = this.input.trim();
+        if (input.length) {
             this.value.update(value => _.uniq([...value, this.input]));
             this.input = '';
         }

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, input, model } from '@angular/core';
+import { Component, computed, input, model } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { actionIcons } from '../icons';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -18,11 +18,14 @@ import _ from 'lodash';
 })
 export class ChipsComponent {
     value = model<string[]>([]);
-    input = '';
     itemName = input.required<string>();
+    limit = input<number>();
 
+    input = '';
     inputConfirmKeys = ['Enter', ',', ';'];
     actionIcons = actionIcons;
+
+    limitReached = computed(() => this.value().length >= (this.limit() ?? Infinity));
 
     handleInputKeydown(event: KeyboardEvent) {
         console.log(event);

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -25,9 +25,16 @@ export class ChipsComponent {
     actionIcons = actionIcons;
 
     handleInputKeydown(event: KeyboardEvent) {
+        console.log(event);
+        // confirm with enter/comma/semicolon
         if (this.inputConfirmKeys.includes(event.key)) {
             event.preventDefault();
             this.confirmInput();
+        }
+        // if input is empty, backspace removes last item
+        if (event.key == 'Backspace' && !event.repeat && !this.input.length && this.value().length) {
+            event.preventDefault();
+            this.removeItem(this.value().length - 1);
         }
     }
 

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -41,4 +41,10 @@ export class ChipsComponent {
             this.input = '';
         }
     }
+
+    removeItem(index: number) {
+        this.value.update(value =>
+            value.filter((_, i) => i !== index)
+        );
+    }
 }

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -28,7 +28,6 @@ export class ChipsComponent {
     limitReached = computed(() => this.value().length >= (this.limit() ?? Infinity));
 
     handleInputKeydown(event: KeyboardEvent) {
-        console.log(event);
         // confirm with enter/comma/semicolon
         if (this.inputConfirmKeys.includes(event.key)) {
             event.preventDefault();

--- a/frontend/src/app/shared/chips/chips.component.ts
+++ b/frontend/src/app/shared/chips/chips.component.ts
@@ -32,13 +32,13 @@ export class ChipsComponent {
     }
 
     onBlur() {
-        if (this.input.length) {
-            this.confirmInput();
-        }
+        this.confirmInput();
     }
 
     confirmInput() {
-        this.value.update(value => _.uniq([...value, this.input]));
-        this.input = '';
+        if (this.input.length) {
+            this.value.update(value => _.uniq([...value, this.input]));
+            this.input = '';
+        }
     }
 }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import { BackToTopButton } from './back-to-top-button/back-to-top-button.compone
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ButtonLoadingDirective } from './button-loading/button-loading.directive';
 import { LoadingDirective } from './loading/loading.directive';
+import { ChipsComponent } from './chips/chips.component';
 
 /** this should be imported by all other modules; provides basic building blocks
  * for the whole application
@@ -33,6 +34,7 @@ import { LoadingDirective } from './loading/loading.directive';
     exports: [
         // shared components
         ButtonLoadingDirective,
+        ChipsComponent,
         LoadingDirective,
         DatePickerComponent,
         ErrorComponent,
@@ -54,6 +56,7 @@ import { LoadingDirective } from './loading/loading.directive';
         SlugifyPipe,
     ], imports: [
         ButtonLoadingDirective,
+        ChipsComponent,
         LoadingDirective,
         ToggleButtonDirective,
         BackToTopButton,

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
@@ -1,6 +1,6 @@
 <form>
     <div class="input-group">
-        <p-autocomplete name="queries" [(ngModel)]="queries" multiple fluid [typeahead]="false" class="flex-grow-1" />
+        <ia-chips [(value)]="queries" inputAriaLabel="add query" />
         <button class="btn btn-primary" (click)="confirmQueries()" [disabled]="!valid(queries)">
             <fa-icon [icon]="formIcons.confirm" aria-hidden="true" class="me-1" />
             Confirm

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
@@ -1,7 +1,7 @@
 <p class="form-label" id="term-comparison-label">Compare search terms</p>
 <form aria-labelledby="term-comparison-label">
     <div class="input-group">
-        <ia-chips [(value)]="queries" itemName="query" />
+        <ia-chips [(value)]="queries" itemName="query" [limit]="termLimit" />
         <button class="btn btn-primary" (click)="confirmQueries()" [disabled]="!valid(queries)">
             <fa-icon [icon]="formIcons.confirm" aria-hidden="true" class="me-1" />
             Confirm

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
@@ -1,4 +1,5 @@
-<form>
+<p class="form-label" id="term-comparison-label">Compare search terms</p>
+<form aria-labelledby="term-comparison-label">
     <div class="input-group">
         <ia-chips [(value)]="queries" itemName="query" />
         <button class="btn btn-primary" (click)="confirmQueries()" [disabled]="!valid(queries)">

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
@@ -1,6 +1,6 @@
 <form>
     <div class="input-group">
-        <ia-chips [(value)]="queries" inputAriaLabel="add query" />
+        <ia-chips [(value)]="queries" itemName="query" />
         <button class="btn btn-primary" (click)="confirmQueries()" [disabled]="!valid(queries)">
             <fa-icon [icon]="formIcons.confirm" aria-hidden="true" class="me-1" />
             Confirm

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -45,6 +45,7 @@ export class TermComparisonEditorComponent implements OnDestroy {
     }
 
     confirmQueries() {
+        console.log(this.queries);
         this.comparedQueries.setParams({compare: this.queries});
     }
 

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -45,7 +45,6 @@ export class TermComparisonEditorComponent implements OnDestroy {
     }
 
     confirmQueries() {
-        console.log(this.queries);
         this.comparedQueries.setParams({compare: this.queries});
     }
 

--- a/frontend/src/app/visualization/visualization.module.ts
+++ b/frontend/src/app/visualization/visualization.module.ts
@@ -1,6 +1,5 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ChartModule } from 'primeng/chart';
 import {
     ApiService,
@@ -49,7 +48,6 @@ import { SelectModule } from 'primeng/select';
         VisualizationComponent,
         ThemeIndicatorDirective
     ], imports: [
-        AutoCompleteModule,
         ChartModule,
         SharedModule,
         SelectModule

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.html
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.html
@@ -1,9 +1,4 @@
-<div class="field">
-    <label class="form-label">Enter one or more terms to compare to "{{queryText}}":</label>
-    <ia-term-comparison-editor
-      [termLimit]="comparisonTermLimit">
-    </ia-term-comparison-editor>
-</div>
+<ia-term-comparison-editor [termLimit]="comparisonTermLimit" />
 
 @if (timeIntervals) {
   <div class="my-3">


### PR DESCRIPTION
Implements a custom "chips" component for term comparison (in the barchart and related words visualisations).

<img width="1349" height="101" alt="screenshot of multi-query input" src="https://github.com/user-attachments/assets/de4598e1-f9cf-4f8e-b271-8593c3bccb72" />


This also fixes some minor UI issues with the component (which were hard to address with a third-party component):
- You can now use commas as separators again. (This was removed in an earlier update, to my annoyance.)
- The typed input is included if you focus out of the input element. This was a problem if the user typed a query and then clicked the confirm button without first hitting "enter".
- When the term comparison reaches the maximum allowed terms, the input is disabled. (Previously, the submit button was disabled but you could still use the input, which makes less sense.)
- In the barchart component, the term comparison menu now shows a label to contextualise it.